### PR TITLE
#16: Removed unnecessary variable from variables.tf

### DIFF
--- a/terraform-etl-iterator/variables.tf
+++ b/terraform-etl-iterator/variables.tf
@@ -14,13 +14,6 @@ variable VPC_ID {
     description = " Holds VPC ID "
 }
 
-variable SECURITY_GROUP_ID {
-    type = string
-    description = " Holds Security Group ID from the VPC "
-}
-
-
-
 variable SUBNET_IDS {
     type = list(string)
     description = " List of Public Subnet IDs "


### PR DESCRIPTION
Exactly the same as the old merge, however the variables.tf did not need the Security_group_id inside of it. Deleted that line. 